### PR TITLE
Now handles multiple enforcer goals

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/RequiredMavenVersionFinder.java
+++ b/src/main/java/org/codehaus/mojo/versions/RequiredMavenVersionFinder.java
@@ -71,7 +71,7 @@ class RequiredMavenVersionFinder {
         }
 
         List<PluginExecution> pluginExecutionsWithEnforceGoal = getPluginExecutionsWithEnforceGoal(pluginExecutions);
-        if (null == pluginExecutionsWithEnforceGoal) {
+        if (pluginExecutionsWithEnforceGoal.isEmpty()) {
             return null;
         }
         
@@ -110,14 +110,14 @@ class RequiredMavenVersionFinder {
                 pluginExecutions.add(pluginExecution);
             }
         }
-        return !pluginExecutions.isEmpty() ? pluginExecutions : null;
+        return pluginExecutions;
     }
 
     private Xpp3Dom getRequireMavenVersionTag(List<PluginExecution> executions) {
         for (PluginExecution pluginExecution : executions) {
             Xpp3Dom configurationTag = (Xpp3Dom) pluginExecution.getConfiguration();
             if (null == configurationTag) {
-                return null;
+                continue;
             }
 
             Xpp3Dom rulesTag = configurationTag.getChild("rules");

--- a/src/main/java/org/codehaus/mojo/versions/RequiredMavenVersionFinder.java
+++ b/src/main/java/org/codehaus/mojo/versions/RequiredMavenVersionFinder.java
@@ -8,6 +8,7 @@ import org.apache.maven.model.Prerequisites;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -69,22 +70,12 @@ class RequiredMavenVersionFinder {
             return null;
         }
 
-        PluginExecution pluginExecutionWithEnforceGoal = getPluginExecutionWithEnforceGoal(pluginExecutions);
-        if (null == pluginExecutionWithEnforceGoal) {
+        List<PluginExecution> pluginExecutionsWithEnforceGoal = getPluginExecutionsWithEnforceGoal(pluginExecutions);
+        if (null == pluginExecutionsWithEnforceGoal) {
             return null;
         }
-
-        Xpp3Dom configurationTag = (Xpp3Dom) pluginExecutionWithEnforceGoal.getConfiguration();
-        if (null == configurationTag) {
-            return null;
-        }
-
-        Xpp3Dom rulesTag = configurationTag.getChild("rules");
-        if (null == rulesTag) {
-            return null;
-        }
-
-        Xpp3Dom requireMavenVersionTag = rulesTag.getChild("requireMavenVersion");
+        
+        Xpp3Dom requireMavenVersionTag = getRequireMavenVersionTag(pluginExecutionsWithEnforceGoal);
         if (null == requireMavenVersionTag) {
             return null;
         }
@@ -111,12 +102,35 @@ class RequiredMavenVersionFinder {
         return null;
     }
 
-    private PluginExecution getPluginExecutionWithEnforceGoal(List<PluginExecution> executions) {
+    private List<PluginExecution> getPluginExecutionsWithEnforceGoal(List<PluginExecution> executions) {
+        List<PluginExecution> pluginExecutions = new ArrayList<>();
         for (PluginExecution pluginExecution : executions) {
             List<String> goals = pluginExecution.getGoals();
             if (goals != null && goals.contains("enforce")) {
-                return pluginExecution;
+                pluginExecutions.add(pluginExecution);
             }
+        }
+        return !pluginExecutions.isEmpty() ? pluginExecutions : null;
+    }
+
+    private Xpp3Dom getRequireMavenVersionTag(List<PluginExecution> executions) {
+        for (PluginExecution pluginExecution : executions) {
+            Xpp3Dom configurationTag = (Xpp3Dom) pluginExecution.getConfiguration();
+            if (null == configurationTag) {
+                return null;
+            }
+
+            Xpp3Dom rulesTag = configurationTag.getChild("rules");
+            if (null == rulesTag) {
+                continue;
+            }
+
+            Xpp3Dom requireMavenVersionTag = rulesTag.getChild("requireMavenVersion");
+            if (null == requireMavenVersionTag) {
+                continue;
+            }
+
+            return requireMavenVersionTag;
         }
         return null;
     }

--- a/src/test/java/org/codehaus/mojo/versions/RequiredMavenVersionFinderTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/RequiredMavenVersionFinderTest.java
@@ -35,9 +35,15 @@ public class RequiredMavenVersionFinderTest {
     @Mock
     private PluginExecution pluginExecution;
     @Mock
+    private PluginExecution otherPluginExecution;
+    @Mock
     private Xpp3Dom configurationTag;
     @Mock
+    private Xpp3Dom otherConfigurationTag;
+    @Mock
     private Xpp3Dom rulesTag;
+    @Mock
+    private Xpp3Dom otherRulesTag;
     @Mock
     private Xpp3Dom requireMavenVersionTag;
     @Mock
@@ -226,6 +232,87 @@ public class RequiredMavenVersionFinderTest {
     public void findReturnsValueWhenVersionTagValueIsValidSimpleRange() {
         String mavenVersionRange = "1.0";
         findReturnsValueWhenVersionTagValueIsSet(mavenVersionRange);
+        DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(mavenVersionRange);
+        assertEquals(artifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsValueWhenSecondEnforcerExecutionIsValidAndFirstEnforcerExecutionHasNoConfigurationTag() {
+        String mavenVersionRange = "1.0";
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(otherPluginExecution);
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        ArrayList<String> otherGoals = new ArrayList<>();
+        goals.add("enforce");
+        otherGoals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(otherPluginExecution.getGoals()).thenReturn(otherGoals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(otherPluginExecution.getConfiguration()).thenReturn(null);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(requireMavenVersionTag);
+        when(requireMavenVersionTag.getChild("version")).thenReturn(versionTag);
+        when(versionTag.getValue()).thenReturn(mavenVersionRange);
+        DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(mavenVersionRange);
+        assertEquals(artifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsValueWhenSecondEnforcerExecutionIsValidAndFirstEnforcerExecutionHasNoRulesTag() {
+        String mavenVersionRange = "1.0";
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(otherPluginExecution);
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        ArrayList<String> otherGoals = new ArrayList<>();
+        goals.add("enforce");
+        otherGoals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(otherPluginExecution.getGoals()).thenReturn(otherGoals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(otherPluginExecution.getConfiguration()).thenReturn(otherConfigurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(otherConfigurationTag.getChild("rules")).thenReturn(null);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(requireMavenVersionTag);
+        when(requireMavenVersionTag.getChild("version")).thenReturn(versionTag);
+        when(versionTag.getValue()).thenReturn(mavenVersionRange);
+        DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(mavenVersionRange);
+        assertEquals(artifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
+    }
+
+    @Test
+    public void findReturnsValueWhenSecondEnforcerExecutionIsValidAndFirstEnforcerExecutionHasNoRequireMavenVersionTag() {
+        String mavenVersionRange = "1.0";
+        ArrayList<Plugin> buildPlugins = new ArrayList<>();
+        buildPlugins.add(enforcerPlugin);
+        when(mavenProject.getBuildPlugins()).thenReturn(buildPlugins);
+        ArrayList<PluginExecution> pluginExecutions = new ArrayList<>();
+        pluginExecutions.add(otherPluginExecution);
+        pluginExecutions.add(pluginExecution);
+        ArrayList<String> goals = new ArrayList<>();
+        ArrayList<String> otherGoals = new ArrayList<>();
+        goals.add("enforce");
+        otherGoals.add("enforce");
+        when(pluginExecution.getGoals()).thenReturn(goals);
+        when(otherPluginExecution.getGoals()).thenReturn(otherGoals);
+        when(enforcerPlugin.getExecutions()).thenReturn(pluginExecutions);
+        when(pluginExecution.getConfiguration()).thenReturn(configurationTag);
+        when(otherPluginExecution.getConfiguration()).thenReturn(otherConfigurationTag);
+        when(configurationTag.getChild("rules")).thenReturn(rulesTag);
+        when(otherConfigurationTag.getChild("rules")).thenReturn(otherRulesTag);
+        when(rulesTag.getChild("requireMavenVersion")).thenReturn(requireMavenVersionTag);
+        when(otherRulesTag.getChild("requireMavenVersion")).thenReturn(null);
+        when(requireMavenVersionTag.getChild("version")).thenReturn(versionTag);
+        when(versionTag.getValue()).thenReturn(mavenVersionRange);
         DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(mavenVersionRange);
         assertEquals(artifactVersion, new RequiredMavenVersionFinder(mavenProject).find());
     }


### PR DESCRIPTION
Related to mojohaus/versions-maven-plugin#230

A valid configuration for the maven-enforcer-plugin is such that you can have multiple executions with their own configurations. The current implementation picks the first enforce goal and checks for the required Maven version in that configuration, but chances are that this configuration actually isn't part of the correct enforce goal. 

Below is an example maven-enforcer-plugin configuration which fails on the display-plugin-updates goal, taken directly from [this file](https://github.com/dannil/scb-java-client/blob/4ab4d87f8b96928371b597a550a92507b35e5656/pom.xml#L435-L523), which is part of the project I used when the unintended behavior was discovered.

```xml
<plugin>
  <groupId>org.apache.maven.plugins</groupId>
  <artifactId>maven-enforcer-plugin</artifactId>
  <version>3.0.0-M1</version>
  <executions>
    <execution>
      <id>enforce-consistency</id>
      <goals>
        <goal>enforce</goal>
      </goals>
      <configuration>
        <rules>
          <dependencyConvergence />
        </rules>
        <fail>true</fail>
      </configuration>
    </execution>
    <execution>
      <id>enforce-banned-dependencies</id>
      <goals>
        <goal>enforce</goal>
      </goals>
      <configuration>
        <rules>
          <bannedDependencies>
            <searchTransitive>true</searchTransitive>
            <excludes>
              <!-- CVE-2015-7501 (https://access.redhat.com/security/cve/cve-2015-7501) -->
              <exclude>commons-collections:commons-collection</exclude>
            </excludes>
          </bannedDependencies>
        </rules>
        <fail>true</fail>
      </configuration>
    </execution>
    <execution>
      <id>enforce-versions</id>
      <goals>
        <goal>enforce</goal>
      </goals>
      <configuration>
        <rules>
          <requireMavenVersion>
            <version>3.0.3</version>
          </requireMavenVersion>
          <requireJavaVersion>
            <version>${project.java.source}</version>
          </requireJavaVersion>
          <requireSameVersions>
            <dependencies>
              <dependency>com.fasterxml.jackson.core:jackson-core</dependency>
              <dependency>com.fasterxml.jackson.core:jackson-databind</dependency>
            </dependencies>
          </requireSameVersions>
          <requireSameVersions>
            <dependencies>
              <dependency>org.apache.logging.log4j:*</dependency>
            </dependencies>
          </requireSameVersions>
          <requireSameVersions>
            <dependencies>
              <dependency>org.junit.jupiter:*</dependency>
            </dependencies>
          </requireSameVersions>
          <requireSameVersions>
            <dependencies>
              <dependency>org.junit.platform:*</dependency>
            </dependencies>
          </requireSameVersions>
        </rules>
        <fail>true</fail>
      </configuration>
    </execution>
    <execution>
      <id>enforce-no-snapshots</id>
      <goals>
        <goal>enforce</goal>
      </goals>
      <configuration>
        <rules>
          <requireReleaseDeps>
            <message>No snapshots allowed as release dependencies.</message>
          </requireReleaseDeps>
        </rules>
        <fail>true</fail>
      </configuration>
    </execution>
  </executions>
</plugin>
```

The changes in the code now checks all the configurations and selects the one that contains the requireMavenVersion tag.